### PR TITLE
Add rule no-trailing-spaces: error

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -76,6 +76,7 @@ rules:
     - selector: 'WhileStatement'
       message: 'Object-Oriented Programming does not require `while` statement.'
   no-return-await: error
+  no-trailing-spaces: error
   no-unexpected-multiline: error
   no-unneeded-ternary:
     - error


### PR DESCRIPTION
## Why

* develop environment improvement.

## How

When execute `npx eslint . --fix`, all trailing spaces will be removed.
