### PR TITLE
Fix README.md duplicated line

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ no-unexpected-multiline
       openreachtech/newline-per-parameter: error
       openreachtech/no-else-if: error
       openreachtech/no-if-in-oneline: error
-      openreachtech/newline-per-parameter: error
 
     ...
     ```

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ no-unexpected-multiline
       openreachtech/newline-per-parameter: error
       openreachtech/no-else-if: error
       openreachtech/no-if-in-oneline: error
+      openreachtech/no-unexpected-multiline: error
 
     ...
     ```


### PR DESCRIPTION
## Why

Fix typo. 
There was duplicated example in README.md.

## How

*
