### PR TITLE
⚙️ Turn on ESLint rule `arrow-parens`

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -4,7 +4,6 @@ ignorePatterns:
   - trials
 rules:
   openreachtech/indent-in-infix-expression: off
-  arrow-parens: off
   object-curly-spacing: off
   no-multi-spaces: off
   jest/valid-title: off

--- a/lib/newline-per-parameter/ParameterNewlineValidator.js
+++ b/lib/newline-per-parameter/ParameterNewlineValidator.js
@@ -18,15 +18,15 @@ class ParameterNewlineValidator {
     this.node = node
 
     this.collectors = {
-      ArrayPattern: (param) => this.deepCollectLines(param.elements),
-      AssignmentPattern: (param) => this.deepCollectLines([param.left]),
-      Identifier: (param) => param.loc.start.line,
-      ObjectPattern: (param) => [
+      ArrayPattern: param => this.deepCollectLines(param.elements),
+      AssignmentPattern: param => this.deepCollectLines([param.left]),
+      Identifier: param => param.loc.start.line,
+      ObjectPattern: param => [
         param.loc.end.line,
         ...this.deepCollectLines(param.properties),
       ],
-      Property: (param) => this.deepCollectLines([param.value]),
-      RestElement: (param) => this.deepCollectLines([param.argument]),
+      Property: param => this.deepCollectLines([param.value]),
+      RestElement: param => this.deepCollectLines([param.argument]),
     }
   }
 


### PR DESCRIPTION
## Why

* See #153