### PR TITLE
⚙️ Turn on ESLint rule `jsdoc/check-types`

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -4,7 +4,6 @@ ignorePatterns:
   - trials
 rules:
   openreachtech/indent-in-infix-expression: off
-  jsdoc/check-types: off
   jsdoc/check-tag-names: off
   prefer-destructuring: off
   jsdoc/check-line-alignment: off

--- a/lib/indent-in-infix-expression/IndentValidator.js
+++ b/lib/indent-in-infix-expression/IndentValidator.js
@@ -192,7 +192,7 @@ class IndentValidator {
    * Fix up.
    *
    * @param {import('eslint').Rule.RuleFixer} fixer - Fixer.
-   * @returns {Object|null} - Instance of Fixer.
+   * @returns {object | null} - Instance of Fixer.
    */
   fix (fixer) {
     const indexOffset = this._calcIndentOffset()

--- a/lib/newline-per-parameter/ParameterNewlineValidator.js
+++ b/lib/newline-per-parameter/ParameterNewlineValidator.js
@@ -7,7 +7,9 @@ class ParameterNewlineValidator {
    *
    * @param {{
    *   context: import('eslint').Rule.RuleContext,
-   *   node: Object.<string, *>,
+   *   node: {
+   *     [key: string]: any,
+   *   },
    * }} params
    */
   constructor ({

--- a/lib/no-comment-in-expression.js
+++ b/lib/no-comment-in-expression.js
@@ -83,7 +83,7 @@ module.exports = {
      * Create error values.
      *
      * @param {Array<import('estree').Comment>} comments - Comments in expression.
-     * @returns {Object} - Expression description.
+     * @returns {object} - Expression description.
      */
     function createErrorValues (comments) {
       return {

--- a/tests/__tests__/indent-in-infix-expression/binary-expression.js
+++ b/tests/__tests__/indent-in-infix-expression/binary-expression.js
@@ -3,7 +3,7 @@
 
 const ESLintHelper = require('../../tools/ESLintHelper')
 
-/** @type {Function|Object} */
+/** @type {Function | object} */
 const ruleBody = require('../../../lib/indent-in-infix-expression')
 
 // ESLint tester instead of Jest `test()`

--- a/tests/__tests__/indent-in-infix-expression/logical-expression.js
+++ b/tests/__tests__/indent-in-infix-expression/logical-expression.js
@@ -3,7 +3,7 @@
 
 const ESLintHelper = require('../../tools/ESLintHelper')
 
-/** @type {Function|Object} */
+/** @type {Function | object} */
 const ruleBody = require('../../../lib/indent-in-infix-expression')
 
 // ESLint tester instead of Jest `test()`

--- a/tests/tools/ESLintHelper.js
+++ b/tests/tools/ESLintHelper.js
@@ -9,7 +9,9 @@ class ESLintHelper {
   /**
    * Create tester instance.
    *
-   * @param {Object.<string, *>} options
+   * @param {{
+   *   [key: string]: *,
+   * }} options
    * @returns {RuleTester} - RuleTester instance.
    */
   static createTester (options = {


### PR DESCRIPTION
## Why

* See #161

