### PR TITLE
⚙️ Turn on ESLint rule `jsdoc/check-tag-names`

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -4,7 +4,6 @@ ignorePatterns:
   - trials
 rules:
   openreachtech/indent-in-infix-expression: off
-  jsdoc/check-tag-names: off
   prefer-destructuring: off
   jsdoc/check-line-alignment: off
   consistent-return: off

--- a/lib/empty-line-after-super.js
+++ b/lib/empty-line-after-super.js
@@ -1,15 +1,15 @@
 // @ts-check
 'use strict'
 
-/**
- * @link
- * https://github.com/estree/estree/blob/53ab1c7dd29e7f1205ee9f6a6691bf6eaad5fb4b/es2015.md#classdeclaration
- * https://github.com/estree/estree/blob/53ab1c7dd29e7f1205ee9f6a6691bf6eaad5fb4b/es2015.md#classbody
- * https://github.com/estree/estree/blob/53ab1c7dd29e7f1205ee9f6a6691bf6eaad5fb4b/es2015.md#methoddefinition
- * https://github.com/estree/estree/blob/8e4059e6f787d9854874729e225b1758a2e02a20/es5.md#functionexpression
- * https://github.com/estree/estree/blob/8e4059e6f787d9854874729e225b1758a2e02a20/es5.md#blockstatement
- * https://github.com/estree/estree/blob/8e4059e6f787d9854874729e225b1758a2e02a20/es5.md#expressionstatement
- * https://github.com/estree/estree/blob/8e4059e6f787d9854874729e225b1758a2e02a20/es5.md#callexpression
+/*
+ * link
+ *   https://github.com/estree/estree/blob/53ab1c7dd29e7f1205ee9f6a6691bf6eaad5fb4b/es2015.md#classdeclaration
+ *   https://github.com/estree/estree/blob/53ab1c7dd29e7f1205ee9f6a6691bf6eaad5fb4b/es2015.md#classbody
+ *   https://github.com/estree/estree/blob/53ab1c7dd29e7f1205ee9f6a6691bf6eaad5fb4b/es2015.md#methoddefinition
+ *   https://github.com/estree/estree/blob/8e4059e6f787d9854874729e225b1758a2e02a20/es5.md#functionexpression
+ *   https://github.com/estree/estree/blob/8e4059e6f787d9854874729e225b1758a2e02a20/es5.md#blockstatement
+ *   https://github.com/estree/estree/blob/8e4059e6f787d9854874729e225b1758a2e02a20/es5.md#expressionstatement
+ *   https://github.com/estree/estree/blob/8e4059e6f787d9854874729e225b1758a2e02a20/es5.md#callexpression
  */
 
 /**

--- a/lib/indent-in-infix-expression.js
+++ b/lib/indent-in-infix-expression.js
@@ -1,10 +1,10 @@
 // @ts-check
 'use strict'
 
-/**
- * @link
- * https://github.com/estree/estree/blob/master/es5.md#binaryexpression
- * https://github.com/estree/estree/blob/master/es5.md#logicalexpression
+/*
+ * link
+ *   https://github.com/estree/estree/blob/master/es5.md#binaryexpression
+ *   https://github.com/estree/estree/blob/master/es5.md#logicalexpression
  */
 
 const IndentValidator = require('./indent-in-infix-expression/IndentValidator')

--- a/lib/no-comment-in-expression.js
+++ b/lib/no-comment-in-expression.js
@@ -1,13 +1,13 @@
 // @ts-check
 'use strict'
 
-/**
- * @link
- * https://github.com/estree/estree/blob/master/es5.md#binaryexpression
- * https://github.com/estree/estree/blob/master/es5.md#conditionalexpression
- * https://github.com/estree/estree/blob/master/es5.md#logicalexpression
- * https://github.com/estree/estree/blob/master/es5.md#unaryexpression
- * https://github.com/estree/estree/blob/master/es5.md#updateexpression
+/*
+ * link
+ *   https://github.com/estree/estree/blob/master/es5.md#binaryexpression
+ *   https://github.com/estree/estree/blob/master/es5.md#conditionalexpression
+ *   https://github.com/estree/estree/blob/master/es5.md#logicalexpression
+ *   https://github.com/estree/estree/blob/master/es5.md#unaryexpression
+ *   https://github.com/estree/estree/blob/master/es5.md#updateexpression
  */
 
 /**

--- a/lib/no-else-if.js
+++ b/lib/no-else-if.js
@@ -1,8 +1,9 @@
 // @ts-check
 'use strict'
 
-/**
- * @link https://github.com/estree/estree/blob/master/es5.md#ifstatement
+/*
+ * link
+ *   https://github.com/estree/estree/blob/master/es5.md#ifstatement
  */
 
 /** @type {import('eslint').Rule.RuleModule} */

--- a/lib/no-if-in-oneline.js
+++ b/lib/no-if-in-oneline.js
@@ -1,11 +1,11 @@
 // @ts-check
 'use strict'
 
-/**
- * @link
- * https://github.com/estree/estree/blob/master/es5.md#ifstatement
- * https://github.com/estree/estree/blob/master/es5.md#emptystatement
- * https://github.com/estree/estree/blob/master/es5.md#blockstatement
+/*
+ * link
+ *   https://github.com/estree/estree/blob/master/es5.md#ifstatement
+ *   https://github.com/estree/estree/blob/master/es5.md#emptystatement
+ *   https://github.com/estree/estree/blob/master/es5.md#blockstatement
  */
 
 /**

--- a/lib/no-unexpected-multiline.js
+++ b/lib/no-unexpected-multiline.js
@@ -1,8 +1,9 @@
 // @ts-check
 'use strict'
 
-/**
- * @link https://github.com/estree/estree/blob/master/es5.md#binaryexpression
+/*
+ * link
+ *   https://github.com/estree/estree/blob/master/es5.md#binaryexpression
  */
 
 const LineBreakValidator = require('./no-unexpected-multiline/LineBreakValidator')


### PR DESCRIPTION
## Why

* See #163

